### PR TITLE
Improve instructions for installation of Hugo on native OS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ git clone https://github.com/redhat-cop/uncontained.io.git
 ```
 2. Navigate to the top level of the repository
 ```
-cd uncontained.io.git
+cd uncontained.io
 ```
 3. Run the site locally
 ```


### PR DESCRIPTION
#### What is this PR About?
Improve instructions for installation of Hugo on native OS.

* Step 2 Installing Hugo on native OS.
* Directory created when repo is cloned is uncontained.io not uncontained.io.git

#### How should we test or review this PR?
clone the repo and verify the directory created is uncontained.io, not uncontained.io.git

#### Is there a relevant Trello card or Github issue open for this?
None

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this

-----

- [ x] Have you followed the [contributing guidelines](https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.md)?
- [ x] Have you explained what your changes do, and why they add value to the uncontained.io guides?

-----

**Please note: we may close your PR without comment if you do not check the boxes above and provide ALL requested information.**
Hard to check boxes when a check mark is not on my keyboard, so I x em.  :)
