### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/redhat-cop/uncontained.io.svg?branch=master)](https://travis-ci.org/redhat-cop/uncontained.io)
 
-This is the source code repository for [Uncontained.io](https://uncontained.io/), a site that focuses on Containers, Cloud, and Digital Transformation guidance for the Enterprise.
+This is the source code repository for [Uncontained.io](http://uncontained.io/), a site that focuses on Containers, Cloud, and Digital Transformation guidance for the Enterprise.
 
 ## Background
 The first sets of uncontained.io guides were created and curated by Red Hat Consultants, along with input from outside community reviewers, but they are not exclusive to Red Hat products.


### PR DESCRIPTION
#### What is this PR About?
Update the link in the readme to not use HTTPS when linking to uncontained.io. Only HTTP is supported currently.

Issue for the underlying problem: #48

#### How should we test or review this PR?
Open the readme and click the link to uncontained.io. Verify that the page opens without certificate errors.

#### Is there a relevant Trello card or Github issue open for this?
No; this is a hotfix.

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this

-----

- [x] Have you followed the [contributing guidelines](https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the uncontained.io guides?

-----

**Please note: we may close your PR without comment if you do not check the boxes above and provide ALL requested information.**
