### PR TITLE
Add styling for admonitions

### DIFF
--- a/site/content/about/brand.adoc
+++ b/site/content/about/brand.adoc
@@ -1,0 +1,16 @@
+---
+title: Brand Elements
+linkTitle: Brand Elements
+---
+
+= Branding and Styling for Uncontained
+
+== Admonitions
+
+NOTE: This is a _Note_ block
+
+TIP: This is a _Tip_ block
+
+WARNING: This warns readers of something not to do
+
+IMPORTANT: This notifies of very critical information

--- a/site/themes/uncontained.io/src/scss/_content.scss
+++ b/site/themes/uncontained.io/src/scss/_content.scss
@@ -35,3 +35,61 @@ time.calendar {
     }
   }
 }
+
+.admonitionblock {
+  background-color: theme-color("dark-blue");
+  box-shadow: 1px 1px 10px;
+  padding: 1em 0;
+  margin: .3em 0 2em -1em;
+  a {
+    color: theme-color("light-blue");
+  }
+  table {
+    border-collapse: separate;
+    border: 0;
+    background: none;
+    color: #fff;
+    font-size: 1.1em;
+    table-layout: fixed;
+    width: 100%;
+    td.icon {
+      font-size: 2em;
+      text-align: center;
+      width: 2.5em;
+      .title {
+        line-height: 0;
+        text-indent: -9999px;
+        visibility: hidden;
+      }
+      .title:before {
+        background-size: 1.5em auto;
+        background-repeat: no-repeat;
+        content: "";
+        display: block;
+        height: 1.5em;
+        margin: 0 .5em 0 .5em;
+        width: 1.5em;
+        visibility: visible;
+      }
+    }
+    td.content {
+      padding: 0 1.5em 0 0;
+    }
+  }
+}
+
+.note table td.icon .title:before {
+    background-image: url('/images/icons/white/rgb_Note_White.png');
+}
+
+.tip table td.icon .title:before {
+    background-image: url('/images/icons/white/rgb_ProTip_White.png');
+}
+
+.warning table td.icon .title:before {
+    background-image: url('/images/icons/white/rgb_WatchOut_White.png');
+}
+
+.important table td.icon .title:before {
+    background-image: url('/images/icons/white/rgb_Info_White.png');
+}


### PR DESCRIPTION
#### What is this PR About?
I've added some basic css for our admonitions.

I've also added a new "hidden" page, which should render under /about/brand/. I thought this could serve as a test page for testing/demonstrating styling techniques, as well as the start of documenting some styling guidance for content writers.

#### How should we test or review this PR?

run `npm start` then navigate around the local site at content where there are NOTE, IMPORTANT, WARNING, or TIP callouts.

#### Is there a relevant Trello card or Github issue open for this?
#32 

#### Who would you like to review this?
cc: @redhat-cop/cant-contain-this

-----

- [x] Have you followed the [contributing guidelines](https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the uncontained.io guides?

-----

**Please note: we may close your PR without comment if you do not check the boxes above and provide ALL requested information.**
