### PR TITLE
Adding non-production mode, agent sharing, and parallel stages to pipeline for easier testing, faster run

### DIFF
--- a/.applier/group_vars/all.yml
+++ b/.applier/group_vars/all.yml
@@ -14,8 +14,8 @@ site_build:
   OUTPUT_IMAGE: "{{ app_name }}:latest"
   OUTPUT_IMAGE_TYPE: ImageStreamTag
   PUSH_SECRET: "name: builder-token-4k28b"
-  APPLICATION_SOURCE_REPO: "{{ source_repo}}"
-  APPLICATION_SOURCE_REF: "{{source_ref}}"
+  APPLICATION_SOURCE_REPO: "{{ source_repo }}"
+  APPLICATION_SOURCE_REF: "{{source_ref }}"
   CI_CD_NAMESPACE: "{{ ci_cd_namespace }}"
   DEV_NAMESPACE: "{{ dev_namespace }}"
   TEST_NAMESPACE: "{{ test_namespace }}"

--- a/.applier/group_vars/all.yml
+++ b/.applier/group_vars/all.yml
@@ -1,5 +1,6 @@
 namespace: uncontained
 app_name: site-v2
+filter_tags: staging
 
 ci_cd_namespace: "{{ namespace }}"
 dev_namespace: "{{ namespace }}-dev"
@@ -34,6 +35,3 @@ test:
 stage:
   NAMESPACE: "{{ stage_namespace }}"
   DISPLAY_NAME: "Uncontained.io - Stage"
-#prod:
-#  NAMESPACE: "{{ prod_namespace }}"
-#  DISPLAY_NAME: "Uncontained.io - Prod"

--- a/.applier/group_vars/all.yml
+++ b/.applier/group_vars/all.yml
@@ -6,7 +6,7 @@ dev_namespace: "{{ namespace }}-dev"
 test_namespace: "{{ namespace }}-test"
 stage_namespace: "{{ namespace }}-stage"
 prod_namespace: field-guides-prod
-source_repo: https://github.com/redhat-cop/uncontained.io
+source_repo: https://github.com/redhat-cop/uncontained.io.git
 source_ref: master
 
 site_build:

--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -67,6 +67,7 @@ openshift_cluster_content:
       NAMESPACE: "{{ ci_cd_namespace }}"
       HYGIEIA_API_URL: "{{ hygieia_url | default('') }}"
       HYGIEIEA_API_TOKEN: "{{ hygieia_token | default('') }}"
+      MEMORY_LIMIT: 2Gi
 - object: Build Pipeline
   content:
   - name: Build Pipeline

--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -40,6 +40,9 @@ openshift_cluster_content:
   - name: Static Files
     file: "{{ inventory_dir }}/../.openshift/files/"
     namespace: "{{ ci_cd_namespace }}"
+    tags:
+      - pre-req
+      - staging
   - name: Apply Image Build
     template: https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/v1.3/jenkins-slaves/templates/jenkins-slave-image-mgmt-template.yml
     namespace: "{{ ci_cd_namespace }}"

--- a/.applier/group_vars/seed-hosts.yml
+++ b/.applier/group_vars/seed-hosts.yml
@@ -10,6 +10,7 @@ openshift_cluster_content:
     tags:
       - project
       - project-{{ ci_cd_namespace }}
+      - staging
   - name: Create {{ dev_namespace }} Project
     template: "{{ inventory_dir }}/../.openshift/projects/projects.yml"
     action: create
@@ -17,6 +18,7 @@ openshift_cluster_content:
     tags:
       - project
       - project-{{ dev_namespace }}
+      - staging
   - name: Create {{ test_namespace }} Project
     template: "{{ inventory_dir }}/../.openshift/projects/projects.yml"
     action: create
@@ -24,6 +26,7 @@ openshift_cluster_content:
     tags:
       - project
       - project-{{ test_namespace }}
+      - staging
   - name: Create {{ stage_namespace }} Project
     template: "{{ inventory_dir }}/../.openshift/projects/projects.yml"
     action: create
@@ -31,6 +34,7 @@ openshift_cluster_content:
     tags:
       - project
       - project-{{ stage_namespace }}
+      - staging
 - object: Pre-requisites
   content:
   - name: Static Files
@@ -41,24 +45,31 @@ openshift_cluster_content:
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - pre-req
+      - staging
   - name: Slave config
     template: "{{ inventory_dir }}/../.openshift/templates/slave-configmap.yml"
     params_from_vars:
       NAMESPACE: "{{ ci_cd_namespace }}"
     tags:
       - pre-req
+      - staging
   - name: Prod cluster credential
     template: "{{ inventory_dir }}/../.openshift/templates/cluster-secret.yml"
     params: "{{ inventory_dir }}/../.openshift/params/prod-cluster-credentials"
     namespace: "{{ ci_cd_namespace }}"
     tags:
       - pre-req
+      - prod
   - name: Hygieia Jenkins Plugin
     template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/master/jenkins-masters/hygieia-plugin/.openshift/templates/hygieia-plugin.yml"
     namespace: "{{ ci_cd_namespace }}"
+    tags:
+      - staging
   - name: Jenkins Master Image
     template: "https://raw.githubusercontent.com/redhat-cop/containers-quickstarts/master/jenkins-masters/hygieia-plugin/.openshift/templates/jenkins-s2i.yml"
     namespace: "{{ ci_cd_namespace }}"
+    tags:
+      - staging
   - name: Deploy Jenkins Master
     template: "{{ inventory_dir }}/../.openshift/templates/jenkins-ephemeral.yml"
     namespace: "{{ ci_cd_namespace }}"
@@ -68,6 +79,8 @@ openshift_cluster_content:
       HYGIEIA_API_URL: "{{ hygieia_url | default('') }}"
       HYGIEIEA_API_TOKEN: "{{ hygieia_token | default('') }}"
       MEMORY_LIMIT: 2Gi
+    tags:
+      - staging
 - object: Build Pipeline
   content:
   - name: Build Pipeline
@@ -77,6 +90,7 @@ openshift_cluster_content:
     tags:
       - build
       - pipeline
+      - staging
 - object: App Deployment {{ dev_namespace }}
   content:
   - name: "create promoter account for {{ dev_namespace }}"
@@ -90,6 +104,7 @@ openshift_cluster_content:
       - deploy-{{ dev_namespace }}
       - deploy-{{ dev_namespace }}-promoter
       - deploy-promoters
+      - staging
   - name: Deployment - {{ dev_namespace }}
     template: "{{ inventory_dir }}/../.openshift/templates/deployment.yml"
     params_from_vars:
@@ -99,6 +114,7 @@ openshift_cluster_content:
       - deploy
       - deploy-{{ dev_namespace }}
       - deploy-{{ dev_namespace }}-app
+      - staging
 - object: App Deployment {{ test_namespace }}
   content:
   - name: "create promoter account for {{ test_namespace }}"
@@ -112,6 +128,7 @@ openshift_cluster_content:
       - deploy-{{ test_namespace }}
       - deploy-{{ test_namespace }}-promoter
       - deploy-promoters
+      - staging
   - name: Deployment - {{ test_namespace }}
     template: "{{ inventory_dir }}/../.openshift/templates/deployment.yml"
     params_from_vars:
@@ -121,6 +138,7 @@ openshift_cluster_content:
       - deploy
       - deploy-{{ test_namespace }}
       - deploy-{{ test_namespace }}-app
+      - staging
 - object: App Deployment {{ stage_namespace }}
   content:
   - name: "create promoter account for {{ stage_namespace }}"
@@ -134,6 +152,7 @@ openshift_cluster_content:
       - deploy-{{ stage_namespace }}
       - deploy-{{ stage_namespace }}-promoter
       - deploy-promoters
+      - prod
   - name: Deployment - {{ stage_namespace }}
     template: "{{ inventory_dir }}/../.openshift/templates/deployment.yml"
     params_from_vars:
@@ -143,3 +162,4 @@ openshift_cluster_content:
       - deploy
       - deploy-{{ stage_namespace }}
       - deploy-{{ stage_namespace }}-app
+      - staging

--- a/.openshift/files/builder-image.yml
+++ b/.openshift/files/builder-image.yml
@@ -31,7 +31,7 @@ items:
 
         USER root
 
-        RUN yum install -y rubygems && yum clean all && gem install asciidoctor
+        RUN yum install -y rubygems && yum clean all && gem install bundler
 
         USER 1001
     strategy:

--- a/.openshift/files/builder-image.yml
+++ b/.openshift/files/builder-image.yml
@@ -31,7 +31,7 @@ items:
 
         USER root
 
-        RUN yum install -y rubygems && yum clean all && gem install bundler
+        RUN yum install -y rubygems && yum clean all && gem install asciidoctor -v 1.5.7
 
         USER 1001
     strategy:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -130,7 +130,31 @@ docker run -u $(id -u) \
   test
 ----
 
-=== Deploying to OpenShift
+==== Deploying to OpenShift (testing only)
+
+The Uncontained.io Jenkins pipeline can be deployed and used purely for testing purposes. Our pipeline can be deployed to any OpenShift cluster, and is automated using link:https://github.com/redhat-cop/openshift-applier[OpenShift Applier]. The following commands can be used to install Applier, log in to your OpenShift cluster, and deploy the pipeline.
+
+[source,bash]
+----
+ansible-galaxy install -r requirements.yml -p galaxy
+oc login ...
+ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml
+----
+
+This will result in the creation of a pipeline and deployment environments across several project:
+
+* `uncontained` is where the link:.openshift/templates/build.yml[Jenkins Pipeline] will be deployed to.
+* `uncontained-dev` will be used as the Development environment, where smoke tests are run.
+* `uncontained-test` and `uncontained-stage` are both promotion environments
+
+If you need to customize the deployment (e.g. for testing a Pull Request), the Applier inventory supports a number of parameters to customize the deployment. The following command is an example of configuring the pipeline to build from an alternative fork and branch. For other possible parameters, see link:.applier/group_vars/all.yml[all.yml].
+
+[source,bash]
+----
+ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e source_repo=https://github.com/etsauer/uncontained.io.git -e source_ref=feature-123
+----
+
+==== Deploying to OpenShift (production process)
 
 Uncontained.io is built and hosted on OpenShift, and deployed using
 https://github.com/redhat-cop/openshift-applier[OpenShift Applier]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -194,7 +194,7 @@ Now, deploy your pipeline and dev environment to your _development_ cluster:
 
 ----
 oc login <dev cluster>
-ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml
+ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e filter_tags=staging,prod
 ----
 
 == Contributing Content

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -130,7 +130,7 @@ docker run -u $(id -u) \
   test
 ----
 
-==== Deploying to OpenShift (testing only)
+=== Deploying to OpenShift (testing only)
 
 The Uncontained.io Jenkins pipeline can be deployed and used purely for testing purposes. Our pipeline can be deployed to any OpenShift cluster, and is automated using link:https://github.com/redhat-cop/openshift-applier[OpenShift Applier]. The following commands can be used to install Applier, log in to your OpenShift cluster, and deploy the pipeline.
 
@@ -154,7 +154,7 @@ If you need to customize the deployment (e.g. for testing a Pull Request), the A
 ansible-playbook -i .applier/ galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml -e source_repo=https://github.com/etsauer/uncontained.io.git -e source_ref=feature-123
 ----
 
-==== Deploying to OpenShift (production process)
+=== Deploying to OpenShift (production process)
 
 Uncontained.io is built and hosted on OpenShift, and deployed using
 https://github.com/redhat-cop/openshift-applier[OpenShift Applier]

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-ruby '2.5.1'
+ruby '2.5.3'
 gem 'asciidoctor', '1.5.7'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,6 @@ pipeline {
     stage ('Build Site from Source') {
       steps {
         container('builder') {
-          sh 'source scl_source enable rh-ruby25 && bundle install'
           sh 'npm install'
           sh 'npm run build'
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
       }
     }
 
-    stage('Promote to Test') {
+    stage('Promotions') {
       agent {
         kubernetes {
           label 'promotion-slave'
@@ -135,97 +135,69 @@ pipeline {
           }
         }
       }
-      steps {
-        script {
-          openshift.withCluster() {
-            openshift.withProject() {
-              echo "Promoting via tag from ${NAMESPACE} to ${TEST_NAMESPACE}/${APP_NAME}"
-              tagImage(sourceImagePath: "${NAMESPACE}", sourceImageName: "${APP_NAME}", toImagePath: "${TEST_NAMESPACE}", toImageName: "${APP_NAME}", toImageTag: "latest")
+      stage('Promote to Test') {
+        steps {
+          script {
+            openshift.withCluster() {
+              openshift.withProject() {
+                echo "Promoting via tag from ${NAMESPACE} to ${TEST_NAMESPACE}/${APP_NAME}"
+                tagImage(sourceImagePath: "${NAMESPACE}", sourceImageName: "${APP_NAME}", toImagePath: "${TEST_NAMESPACE}", toImageName: "${APP_NAME}", toImageTag: "latest")
+              }
             }
+            sh 'mkdir dist/'
+            sh 'touch dist/index.html'
+            hygieiaDeployPublishStep applicationName: "${APP_NAME}", artifactDirectory: 'dist/', artifactGroup: 'uncontained.io', artifactName: 'index.html', artifactVersion: "${BUILD_NUMBER}-${TEST_NAMESPACE}", buildStatus: 'Success', environmentName: "${TEST_NAMESPACE}"
           }
-          sh 'mkdir dist/'
-          sh 'touch dist/index.html'
-          hygieiaDeployPublishStep applicationName: "${APP_NAME}", artifactDirectory: 'dist/', artifactGroup: 'uncontained.io', artifactName: 'index.html', artifactVersion: "${BUILD_NUMBER}-${TEST_NAMESPACE}", buildStatus: 'Success', environmentName: "${TEST_NAMESPACE}"
         }
       }
+
+      stage('Promote to Stage') {
+        steps {
+          script {
+            openshift.withCluster() {
+              openshift.withProject() {
+                echo "Promoting via tag from ${NAMESPACE} to ${STAGE_NAMESPACE}/${APP_NAME}"
+                tagImage(sourceImagePath: "${NAMESPACE}", sourceImageName: "${APP_NAME}", toImagePath: "${STAGE_NAMESPACE}", toImageName: "${APP_NAME}", toImageTag: "latest")
+              }
+            }
+            sh 'mkdir dist/'
+            sh 'touch dist/index.html'
+            hygieiaDeployPublishStep applicationName: "${APP_NAME}", artifactDirectory: 'dist/', artifactGroup: 'uncontained.io', artifactName: 'index.html', artifactVersion: "${BUILD_NUMBER}-${STAGE_NAMESPACE}", buildStatus: 'Success', environmentName: "${STAGE_NAMESPACE}"
+          }
+        }
+      }
+
+      stage('Promote to Prod') {
+        when {
+          beforeAgent true
+          allOf{
+            environment name: 'APPLICATION_SOURCE_REF', value: 'master';
+            environment name: 'APPLICATION_SOURCE_REPO', value: 'https://github.com/redhat-cop/uncontained.io.git'
+          }
+        }
+        steps {
+          script {
+            openshift.withCluster() {
+
+              openshift.withProject() {
+                def imageRegistry = openshift.selector( 'is', "${APP_NAME}").object().status.dockerImageRepository
+                echo "Promoting ${imageRegistry} -> ${registry}/${PROD_NAMESPACE}/${APP_NAME}"
+                sh """
+                set +x
+                skopeo copy --remove-signatures \
+                  --src-creds openshift:${localToken} --src-cert-dir=/run/secrets/kubernetes.io/serviceaccount/ \
+                  --dest-creds openshift:${token}  --dest-tls-verify=false \
+                  docker://${imageRegistry} docker://${registry}/${PROD_NAMESPACE}/${APP_NAME}
+                """
+                sh 'mkdir dist/ && touch dist/index.html'
+                hygieiaDeployPublishStep applicationName: "${APP_NAME}", artifactDirectory: 'dist/', artifactGroup: 'uncontained.io', artifactName: 'index.html', artifactVersion: "${BUILD_NUMBER}-${PROD_NAMESPACE}", buildStatus: 'Success', environmentName: "${PROD_NAMESPACE}"
+              }
+
+            }
+          }
+
+        }
     }
-
-    stage('Promote to Stage') {
-      agent {
-        kubernetes {
-          label 'promotion-slave'
-          cloud 'openshift'
-          serviceAccount 'jenkins'
-          containerTemplate {
-            name 'jnlp'
-            image "docker-registry.default.svc:5000/${NAMESPACE}/jenkins-slave-image-mgmt"
-            alwaysPullImage true
-            workingDir '/tmp'
-            args '${computer.jnlpmac} ${computer.name}'
-            ttyEnabled false
-          }
-        }
-      }
-      steps {
-        script {
-          openshift.withCluster() {
-            openshift.withProject() {
-              echo "Promoting via tag from ${NAMESPACE} to ${STAGE_NAMESPACE}/${APP_NAME}"
-              tagImage(sourceImagePath: "${NAMESPACE}", sourceImageName: "${APP_NAME}", toImagePath: "${STAGE_NAMESPACE}", toImageName: "${APP_NAME}", toImageTag: "latest")
-            }
-          }
-          sh 'mkdir dist/'
-          sh 'touch dist/index.html'
-          hygieiaDeployPublishStep applicationName: "${APP_NAME}", artifactDirectory: 'dist/', artifactGroup: 'uncontained.io', artifactName: 'index.html', artifactVersion: "${BUILD_NUMBER}-${STAGE_NAMESPACE}", buildStatus: 'Success', environmentName: "${STAGE_NAMESPACE}"
-        }
-      }
-    }
-
-    stage('Promote to Prod') {
-      when {
-        beforeAgent true
-        allOf{
-          environment name: 'APPLICATION_SOURCE_REF', value: 'master';
-          environment name: 'APPLICATION_SOURCE_REPO', value: 'https://github.com/redhat-cop/uncontained.io.git'
-        }
-      }
-      agent {
-        kubernetes {
-          label 'promotion-slave'
-          cloud 'openshift'
-          serviceAccount 'jenkins'
-          containerTemplate {
-            name 'jnlp'
-            image "docker-registry.default.svc:5000/${NAMESPACE}/jenkins-slave-image-mgmt"
-            alwaysPullImage true
-            workingDir '/tmp'
-            args '${computer.jnlpmac} ${computer.name}'
-            ttyEnabled false
-          }
-        }
-      }
-      steps {
-        script {
-          openshift.withCluster() {
-
-            openshift.withProject() {
-              def imageRegistry = openshift.selector( 'is', "${APP_NAME}").object().status.dockerImageRepository
-              echo "Promoting ${imageRegistry} -> ${registry}/${PROD_NAMESPACE}/${APP_NAME}"
-              sh """
-              set +x
-              skopeo copy --remove-signatures \
-                --src-creds openshift:${localToken} --src-cert-dir=/run/secrets/kubernetes.io/serviceaccount/ \
-                --dest-creds openshift:${token}  --dest-tls-verify=false \
-                docker://${imageRegistry} docker://${registry}/${PROD_NAMESPACE}/${APP_NAME}
-              """
-              sh 'mkdir dist/ && touch dist/index.html'
-              hygieiaDeployPublishStep applicationName: "${APP_NAME}", artifactDirectory: 'dist/', artifactGroup: 'uncontained.io', artifactName: 'index.html', artifactVersion: "${BUILD_NUMBER}-${PROD_NAMESPACE}", buildStatus: 'Success', environmentName: "${PROD_NAMESPACE}"
-            }
-
-          }
-        }
-
-      }
     }
   }
   /*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     stage ('Build Site from Source') {
       steps {
         container('builder') {
-          sh 'bundle install'
+          sh 'source scl_source enable rh-ruby25 && bundle install'
           sh 'npm install'
           sh 'npm run build'
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
     stage ('Build Site from Source') {
       steps {
         container('builder') {
+          sh 'bundle install'
           sh 'npm install'
           sh 'npm run build'
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,17 +1,7 @@
 @Library('cop-library') _
 
 openshift.withCluster() {
-  env.NAMESPACE = openshift.project()
-
   env.localToken = readFile('/var/run/secrets/kubernetes.io/serviceaccount/token').trim()
-
-  def secretData = openshift.selector('secret/other-cluster-credentials').object().data
-  def encodedRegistry = secretData.registry
-  def encodedToken = secretData.token
-  def encodedAPI = secretData.api
-  env.registry = sh(script:"set +x; echo ${encodedRegistry} | base64 --decode", returnStdout: true)
-  env.token = sh(script:"set +x; echo ${encodedToken} | base64 --decode", returnStdout: true)
-  env.api = sh(script:"set +x; echo ${encodedAPI} | base64 --decode", returnStdout: true)
 }
 
 //n.notifyBuild('STARTED', rocketchat_url)
@@ -181,6 +171,15 @@ pipeline {
           steps {
             script {
               openshift.withCluster() {
+                env.NAMESPACE = openshift.project()
+
+                def secretData = openshift.selector('secret/other-cluster-credentials').object().data
+                def encodedRegistry = secretData.registry
+                def encodedToken = secretData.token
+                def encodedAPI = secretData.api
+                env.registry = sh(script:"set +x; echo ${encodedRegistry} | base64 --decode", returnStdout: true)
+                env.token = sh(script:"set +x; echo ${encodedToken} | base64 --decode", returnStdout: true)
+                env.api = sh(script:"set +x; echo ${encodedAPI} | base64 --decode", returnStdout: true)
 
                 openshift.withProject() {
                   def imageRegistry = openshift.selector( 'is', "${APP_NAME}").object().status.dockerImageRepository

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,8 +145,7 @@ pipeline {
                   tagImage(sourceImagePath: "${NAMESPACE}", sourceImageName: "${APP_NAME}", toImagePath: "${TEST_NAMESPACE}", toImageName: "${APP_NAME}", toImageTag: "latest")
                 }
               }
-              sh 'mkdir dist/'
-              sh 'touch dist/index.html'
+              sh 'mkdir -p dist/ && touch dist/index.html'
               hygieiaDeployPublishStep applicationName: "${APP_NAME}", artifactDirectory: 'dist/', artifactGroup: 'uncontained.io', artifactName: 'index.html', artifactVersion: "${BUILD_NUMBER}-${TEST_NAMESPACE}", buildStatus: 'Success', environmentName: "${TEST_NAMESPACE}"
             }
           }
@@ -161,8 +160,7 @@ pipeline {
                   tagImage(sourceImagePath: "${NAMESPACE}", sourceImageName: "${APP_NAME}", toImagePath: "${STAGE_NAMESPACE}", toImageName: "${APP_NAME}", toImageTag: "latest")
                 }
               }
-              sh 'mkdir dist/'
-              sh 'touch dist/index.html'
+              sh 'mkdir -p dist/ && touch dist/index.html'
               hygieiaDeployPublishStep applicationName: "${APP_NAME}", artifactDirectory: 'dist/', artifactGroup: 'uncontained.io', artifactName: 'index.html', artifactVersion: "${BUILD_NUMBER}-${STAGE_NAMESPACE}", buildStatus: 'Success', environmentName: "${STAGE_NAMESPACE}"
             }
           }
@@ -190,7 +188,7 @@ pipeline {
                     --dest-creds openshift:${token}  --dest-tls-verify=false \
                     docker://${imageRegistry} docker://${registry}/${PROD_NAMESPACE}/${APP_NAME}
                   """
-                  sh 'mkdir dist/ && touch dist/index.html'
+                  sh 'mkdir -p dist/ && touch dist/index.html'
                   hygieiaDeployPublishStep applicationName: "${APP_NAME}", artifactDirectory: 'dist/', artifactGroup: 'uncontained.io', artifactName: 'index.html', artifactVersion: "${BUILD_NUMBER}-${PROD_NAMESPACE}", buildStatus: 'Success', environmentName: "${PROD_NAMESPACE}"
                 }
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,6 +182,13 @@ pipeline {
     }
 
     stage('Promote to Prod') {
+      when {
+        beforeAgent: true
+        allOf{
+          environment name: 'APPLICATION_SOURCE_REF', value: 'master';
+          environment name: 'APPLICATION_SOURCE_REPO', value: 'https://github.com/redhat-cop/uncontained.io.git'
+        }
+      }
       agent {
         kubernetes {
           label 'promotion-slave'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,7 +183,7 @@ pipeline {
 
     stage('Promote to Prod') {
       when {
-        //beforeAgent: true
+        beforeAgent true
         allOf{
           environment name: 'APPLICATION_SOURCE_REF', value: 'master';
           environment name: 'APPLICATION_SOURCE_REPO', value: 'https://github.com/redhat-cop/uncontained.io.git'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,20 +52,24 @@ pipeline {
       }
     }
 
-    stage ('Run Automated Tests') {
-      steps {
-        container('builder') {
-          sh 'npm test'
+    stage ('Build and Test in Parallel') {
+      parallel {
+        stage ('Run Automated Tests') {
+          steps {
+            container('builder') {
+              sh 'npm test'
+            }
+          }
         }
-      }
-    }
 
-    stage ('Build Container Image') {
-      steps {
-        script {
-          openshift.withCluster() {
-            openshift.withProject() {
-              openshift.selector("bc", "${APP_NAME}").startBuild("--from-dir=dist").logs("-f")
+        stage ('Build Container Image') {
+          steps {
+            script {
+              openshift.withCluster() {
+                openshift.withProject() {
+                  openshift.selector("bc", "${APP_NAME}").startBuild("--from-dir=dist").logs("-f")
+                }
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 
 openshift.withCluster() {
   env.localToken = readFile('/var/run/secrets/kubernetes.io/serviceaccount/token').trim()
+  env.NAMESPACE = openshift.project()
 }
 
 //n.notifyBuild('STARTED', rocketchat_url)
@@ -172,8 +173,6 @@ pipeline {
           steps {
             script {
               openshift.withCluster() {
-                env.NAMESPACE = openshift.project()
-
                 def secretData = openshift.selector('secret/other-cluster-credentials').object().data
                 def encodedRegistry = secretData.registry
                 def encodedToken = secretData.token

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,7 +183,7 @@ pipeline {
 
     stage('Promote to Prod') {
       when {
-        beforeAgent: true
+        //beforeAgent: true
         allOf{
           environment name: 'APPLICATION_SOURCE_REF', value: 'master';
           environment name: 'APPLICATION_SOURCE_REPO', value: 'https://github.com/redhat-cop/uncontained.io.git'

--- a/container-images/local-dev/Dockerfile
+++ b/container-images/local-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1-slim
+FROM ruby:2.5.3-slim
 
 ENV NODE_VERSION v10.15.1
 ENV PATH /node/node-${NODE_VERSION}-linux-x64/bin:${PATH}


### PR DESCRIPTION
#### What is this PR About?

This PR adds a conditional check to the jenkinsfile, ensuring that the `Promote to Prod` stage only runs when `source_repo == https://github.com/redhat-cop/uncontained.io.git` and `source_ref == master`. This way, it will be easier for contributors to run the pipeline cleanly without need for the production secret.

#### How should we test or review this PR?

There is a new section in CONTRIBUTING.md on running the pipeline for non-prod testing purposes. Follow the instructions there to deploy/test the pipeline. There is an example command there for testing against an alternate fork/branch... just change the last argument to `-e source_ref=stage-pipeline` to test against this branch.

#### Is there a relevant Trello card or Github issue open for this?

n/a

#### Who would you like to review this?

cc: @redhat-cop/cant-contain-this

'''''

* [x] Have you followed the
https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.md[contributing
guidelines]?
* [x] Have you explained what your changes do, and why they add value to
the uncontained.io guides?

'''''

*Please note: we may close your PR without comment if you do not check
the boxes above and provide ALL requested information.*
