### PR TITLE
Update applier version to work with ansible 2.8

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -5,4 +5,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.3
+  version: v2.0.10


### PR DESCRIPTION
#### What is this PR About?

Upgrade to latest openshift-applier version, which adds support for ansible 2.8

#### How should we test or review this PR?

Follow the [Deploying to OpenShift](https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.adoc#deploying-to-openshift-testing-only) instructions in the Contribution Guide on a machine with Ansible 2.8

#### Is there a relevant Trello card or Github issue open for this?

n/a

#### Who would you like to review this?

cc: @redhat-cop/cant-contain-this

'''''

* [x] Have you followed the
https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.md[contributing
guidelines]?
* [x] Have you explained what your changes do, and why they add value to
the uncontained.io guides?

'''''

*Please note: we may close your PR without comment if you do not check
the boxes above and provide ALL requested information.*
