### PR TITLE
Fix for #83.

### DIFF
--- a/.openshift/files/builder-image.yml
+++ b/.openshift/files/builder-image.yml
@@ -31,7 +31,7 @@ items:
 
         USER root
 
-        RUN yum install -y rubygems && yum clean all && gem install asciidoctor -v 1.5.7
+        RUN yum install -y rubygems git && yum clean all && gem install asciidoctor -v 1.5.7
 
         USER 1001
     strategy:

--- a/container-images/local-dev/Dockerfile
+++ b/container-images/local-dev/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 COPY container-images/local-dev/root /
 
 RUN apt-get update &&\
-  apt-get -y install curl tar xz-utils && \
+  apt-get -y install curl tar git xz-utils && \
   mkdir -p /node && \
   curl -o /node/node.tar.xz https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz && \
   tar -xf /node/node.tar.xz --directory=/node && \

--- a/site/config.toml
+++ b/site/config.toml
@@ -11,6 +11,7 @@ Paginate = 10
 preserveTaxonomyNames = true
 
 enableRobotsTXT = true # generate robots.txt
+enableGitInfo = true   # enable usage of git info for lastmod
 
 # Syntax Highlighting ( https://gohugo.io/content-management/syntax-highlighting/ )
 pygmentsCodefencesGuessSyntax = true

--- a/site/themes/uncontained.io/layouts/partials/date.html
+++ b/site/themes/uncontained.io/layouts/partials/date.html
@@ -1,1 +1,7 @@
-<time class="calendar">{{ .Date.Format "January 2 2006" }}</time>
+<time class="calendar">
+{{ if not .Lastmod.IsZero }}
+    {{ .Lastmod.Format "January 2 2006" }}
+{{ else }}
+    {{ .Date.Format "January 2 2006" }}
+{{ end }}
+</time>


### PR DESCRIPTION
#### What is this PR About?

resolves #83 - automatically using the lastmod date from Git when available.

#### How should we test or review this PR?

Testing is slightly involved, since I needed to make a small mod to the container image (for installing git) to make this work:

1. Build the container image using the instructions in the contributing section.
2. Run the tests using the container image built in step 1.
3. Verify by inspection that the dates associated with each article are pulling from git.

Note that before we merge this, we'll need to update the image out on quay, or tests using the image there will fail (since git isn't available on the PATH).

#### Is there a relevant Trello card or Github issue open for this?

resolves https://github.com/redhat-cop/uncontained.io/issues/83.

#### Who would you like to review this?

@etsauer, since he opened the issue.
