### PR TITLE
change the required version of hugo

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gulp-sass": "^4.0.2",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-util": "^3.0.8",
-    "hugo-bin": "^0.37.0",
+    "hugo-bin": "^0.58.0",
     "humanize-duration": "^3.18.0",
     "lunr": "^2.3.6",
     "toml": "^3.0.0"


### PR DESCRIPTION
What is this PR About?
hugo version 0.38.0 causes an error when it tries to create a new article.

How should we test or review this PR?
none

Is there a relevant Trello card or Github issue open for this?
resolves #170

Who would you like to review this?
cc: @redhat-cop/cant-contain-this @etsauer

'''''

[V] Have you followed the
https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.md[contributing
guidelines]?
[V] Have you explained what your changes do, and why they add value to
the uncontained.io guides?
'''''

Please note: we may close your PR without comment if you do not check
the boxes above and provide ALL requested information.