### PR TITLE
Uncontained.io local-dev image update to use RHEL8 ubi8-minimal as a base image

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -59,7 +59,12 @@ created as others will do so if they appreciate it.
 Before you begin contributing, its important to get your local machine set up to run and test the site. For convenience, we provide a link:container-images/local-dev/[container image] that contains all of the development tools. The simplest way to run the image is as follows:
 
 ----
-docker run quay.io/redhat-cop/uncontained-local-dev
+podman run -p 3000:3000 -p 3001:3001 quay.io/redhat-cop/uncontained-local-dev
+----
+
+Or, if you use Docker:
+----
+docker run -p 3000:3000 -p 3001:3001 quay.io/redhat-cop/uncontained-local-dev
 ----
 
 This will run uncontained.io from an embedded copy of the source code baked into the image.
@@ -87,38 +92,42 @@ The live preview provides an embedded server in which you can test the
 site locally, and watch changes being made as you develop. You can start the server, running from your local copy of the code using the container image:
 
 ----
-docker run -u $(id -u) \
+podman run -u $(id -u) \
   -v ${PWD}:/uncontained.io:Z -it \
-  --net=host quay.io/redhat-cop/uncontained-local-dev
+  -p 3000:3000 -p 3001:3001 quay.io/redhat-cop/uncontained-local-dev
 ----
 
-Docker Desktop for Mac:
+Or, if you use Docker:
 ----
 docker run -u $(id -u) \
   -v ${PWD}:/uncontained.io:Z -it \
-  -p 3000:3000 quay.io/redhat-cop/uncontained-local-dev
+  -p 3000:3000 -p 3001:3001 quay.io/redhat-cop/uncontained-local-dev
 ----
 
 The container also accepts extra arguments which it feeds to `npm`. For example, if you’d like to also include _draft_ content like
 `hugo server --buildDrafts --buildFuture`, we've created a script entry in our package.json for that:
 
 ----
-docker run -u $(id -u) \
+podman run -u $(id -u) \
   -v ${PWD}:/uncontained.io:Z -it \
-  --net=host quay.io/redhat-cop/uncontained-local-dev \
+  -p 3000:3000 -p 3001:3001 quay.io/redhat-cop/uncontained-local-dev \
   run start-preview
 ----
 
-Docker Desktop for Mac:
+Or, if you use Docker:
 ----
 docker run -u $(id -u) \
   -v ${PWD}:/uncontained.io:Z -it \
-  -p 3000:3000 quay.io/redhat-cop/uncontained-local-dev \
+  -p 3000:3000 -p 3001:3001 quay.io/redhat-cop/uncontained-local-dev \
   run start-preview
 ----
 
 You should be able to view the site by browsing to
 http://localhost:3000/.
+
+To open Browsersync browse to
+http://localhost:3001/.
+
 
 === Building the Site
 
@@ -127,17 +136,17 @@ javascript, etc. This is the process we use to build and publish the
 site.
 
 ----
-docker run -u $(id -u) \
+podman run -u $(id -u) \
   -v ${PWD}:/uncontained.io:Z -it \
-  --net=host quay.io/redhat-cop/uncontained-local-dev \
+  quay.io/redhat-cop/uncontained-local-dev \
   run build
 ----
 
-Docker Desktop for Mac:
+Or, if you use Docker:
 ----
 docker run -u $(id -u) \
   -v ${PWD}:/uncontained.io:Z -it \
-  -p 3000:3000 quay.io/redhat-cop/uncontained-local-dev \
+  quay.io/redhat-cop/uncontained-local-dev \
   run build
 ----
 
@@ -147,19 +156,20 @@ In order to validate that changes you've made haven't led to any unforeseen issu
 the container image to run our automated tests.
 
 ----
-docker run -u $(id -u) \
+podman run -u $(id -u) \
   -v ${PWD}:/uncontained.io:Z -it \
-  --net=host quay.io/redhat-cop/uncontained-local-dev \
+  quay.io/redhat-cop/uncontained-local-dev \
   test
 ----
 
-Docker Desktop for Mac:
+Or, if you use Docker:
 ----
 docker run -u $(id -u) \
   -v ${PWD}:/uncontained.io:Z -it \
-  -p 3000:3000 quay.io/redhat-cop/uncontained-local-dev \
+  quay.io/redhat-cop/uncontained-local-dev \
   test
 ----
+
 
 === Deploying to OpenShift (testing only)
 

--- a/container-images/local-dev/Dockerfile
+++ b/container-images/local-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3-slim
+FROM registry.access.redhat.com/ubi8-minimal
 
 ENV NODE_VERSION v10.15.1
 ENV PATH /node/node-${NODE_VERSION}-linux-x64/bin:${PATH}
@@ -10,8 +10,8 @@ WORKDIR /uncontained.io
 COPY . .
 COPY container-images/local-dev/root /
 
-RUN apt-get update &&\
-  apt-get -y install curl tar git xz-utils && \
+RUN microdnf update &&\
+  microdnf -y install tar git xz ruby rubygem-bundler && \
   mkdir -p /node && \
   curl -o /node/node.tar.xz https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz && \
   tar -xf /node/node.tar.xz --directory=/node && \

--- a/container-images/local-dev/Dockerfile
+++ b/container-images/local-dev/Dockerfile
@@ -7,7 +7,6 @@ ENV USER_UID 1001
 
 WORKDIR /uncontained.io
 
-COPY . .
 COPY container-images/local-dev/root /
 
 RUN microdnf update &&\

--- a/container-images/local-dev/README.adoc
+++ b/container-images/local-dev/README.adoc
@@ -9,7 +9,7 @@ If you are working on improvements to the image however, you can build it locall
 [source,bash]
 ----
 cd uncontained.io/
-buildah build -f container-images/local-dev/Dockerfile -t uncontained-local-dev .
+buildah bud -f container-images/local-dev/Dockerfile -t uncontained-local-dev .
 ----
 
 

--- a/container-images/local-dev/README.adoc
+++ b/container-images/local-dev/README.adoc
@@ -9,5 +9,15 @@ If you are working on improvements to the image however, you can build it locall
 [source,bash]
 ----
 cd uncontained.io/
-docker build -f container-images/local-dev/Dockerfile -t uncontained-local-dev .
+buildah build -f container-images/local-dev/Dockerfile -t uncontained-local-dev .
 ----
+
+
+To run the image you can use the following commands:
+
+[source,bash]
+----
+podman run -u $(id -u) -v ${PWD}:/uncontained.io:Z -it --rm -p 3000:3000 -p 3001:3001 uncontained-local-dev
+----
+
+After this uncontained.io will be available locally via http://localhost:3000 or http://localhost:3001 for Browsersync.

--- a/container-images/local-dev/README.adoc
+++ b/container-images/local-dev/README.adoc
@@ -13,7 +13,17 @@ buildah build -f container-images/local-dev/Dockerfile -t uncontained-local-dev 
 ----
 
 
-To run the image you can use the following commands:
+To run the image you can use the following command:
+
+[source,bash]
+----
+podman run --rm -p 3000:3000 -p 3001:3001 uncontained-local-dev
+----
+
+This command will run uncontained.io usin embedded copy of the source code.
+
+
+If you need to run it with actual code use this:
 
 [source,bash]
 ----

--- a/container-images/local-dev/root/usr/local/bin/user_setup
+++ b/container-images/local-dev/root/usr/local/bin/user_setup
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -x
 
-# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be). Also clone git repo.
 mkdir -p ${HOME}
+git clone https://github.com/redhat-cop/uncontained.io.git ${HOME}
 chown -R ${USER_UID}:0 ${HOME}
 chmod ug+rwx ${HOME}
 


### PR DESCRIPTION
#### What is this PR About?

Uncontained local-dev container image updated to use RHEL UBI8-minimal as a base image instead of ruby:2.5.3-slim.
Also fixed error - previous version of the image was not able to start with embedded code because it uses COPY instead of git clone (npm cannot start if git is not initialized).
COPY replaced with git clone command.

README file updated with buildah/podman commands instead of docker.

#### How should we test or review this PR?

To build:
buildah bud -f container-images/local-dev/Dockerfile -t uncontained-local-dev .

To run with embedded source code:
podman run -it localhost/uncontained-local-dev

To run with local copy of the source code
podman run -u $(id -u) -v ${PWD}:/uncontained.io:Z -it --rm -p 3000:3000 -p 3001:3001 uncontained-local-dev

#### Is there a relevant Trello card or Github issue open for this?

It is from RHTE CoP Hackaton

#### Who would you like to review this?

cc: @redhat-cop/cant-contain-this

'''''

* [V] Have you followed the
[contributing
guidelines?](https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.adoc)
* [V] Have you explained what your changes do, and why they add value to
the uncontained.io guides?

'''''

*Please note: we may close your PR without comment if you do not check
the boxes above and provide ALL requested information.*