### PR TITLE
Fixed text out of homepage summary boxes (#85)

### DIFF
--- a/site/content/articles/devops-reading-list.adoc
+++ b/site/content/articles/devops-reading-list.adoc
@@ -41,7 +41,7 @@ OK, so now you have some base understand about what DevOps is. This section is i
 * link:http://blog.crisp.se/2016/01/25/henrikkniberg/making-sense-of-mvp[Making Sense of MVP] (Article)
 * link:http://itrevolution.com/learn-more-about-concepts-in-phoenix-project/[Phoenix Project Reference Guide part 1] and link:http://itrevolution.com/resource-guide-for-the-phoenix-project-kanbans-part-2/[Part 2] (Articles)
 * link:http://theleanstartup.com/book[The Lean Startup] (Book)
-* link:http://personalkanban.com/pk/book/[Personal Kanban] (Book)
+* link:https://www.personalkanban.com/[Personal Kanban] (Book)
 
 == Deep Dives & Further Learning
 

--- a/site/content/articles/openshift-load-balancing.adoc
+++ b/site/content/articles/openshift-load-balancing.adoc
@@ -93,7 +93,7 @@ TIP: By default, the use of a Ramp Node creates a single point of failure. To av
 image::/images/load_balancing_full.jpg[Full Integration]
 
 For more information on configuration, view the routing section of the official OpenShift Enterprise docs:
-{docs_url}install_config/router/f5_router.html
+{docs_url}install_config/router/index.html
 
 == Load Balancing For HA Master Infrastructure
 

--- a/site/themes/uncontained.io/src/scss/_home.scss
+++ b/site/themes/uncontained.io/src/scss/_home.scss
@@ -54,10 +54,10 @@
 
 .summary {
   background-color: theme-color("white");
-  height: 22em;
+  min-height: 22em;
   margin: 1em 2em;
   padding-top: 0;
-  padding-bottom: 1em;
+  padding-bottom: 2em;
   h2 {
     font-size: 1.1em;
     a {
@@ -78,10 +78,9 @@
   }
   .read-more {
     font-weight: 500;
-    margin-top: 2em;
+    padding: 0 1em;
     a {
       color: theme-color("dark-blue");
-      padding: 0.4em .8em;
       &:hover, &:focus {
         color: theme-color("medium-blue");
         text-decoration: none;


### PR DESCRIPTION
#### What is this PR About?
Updated _home.scss for the .summary class to prevent text from flow out of homepage summary boxes.

#### How should we test or review this PR?
Running the container and viewing it locally across different browsers.
![Screenshot for GitHub issue 85](https://user-images.githubusercontent.com/16334194/82482891-d4f9ac80-9ad7-11ea-98a6-fa056ed78368.png)

#### Is there a relevant Trello card or Github issue open for this?
Yes, GitHub issue #85 

#### Who would you like to review this?
@rdebeasi and/or @cmwylie19
cc: @redhat-cop/cant-contain-this

'''''

* [x] Have you followed the [contributing guidelines?](https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.adoc)
* [x] Have you explained what your changes do, and why they add value to
the uncontained.io guides?

'''''

*Please note: we may close your PR without comment if you do not check
the boxes above and provide ALL requested information.*