### PR TITLE
Updating node version to make local-dev work for docker

### DIFF
--- a/container-images/local-dev/Dockerfile
+++ b/container-images/local-dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8-minimal
 
-ENV NODE_VERSION v10.15.1
+ENV NODE_VERSION v10.23.0
 ENV PATH /node/node-${NODE_VERSION}-linux-x64/bin:${PATH}
 ENV HOME /uncontained.io
 ENV USER_UID 1001

--- a/container-images/local-dev/README.adoc
+++ b/container-images/local-dev/README.adoc
@@ -12,6 +12,14 @@ cd uncontained.io/
 buildah bud -f container-images/local-dev/Dockerfile -t uncontained-local-dev .
 ----
 
+Or, if you use Docker:
+
+[source,bash]
+----
+cd uncontained.io/
+docker build -f container-images/local-dev/Dockerfile -t uncontained-local-dev .
+----
+
 
 To run the image you can use the following command:
 
@@ -20,7 +28,7 @@ To run the image you can use the following command:
 podman run --rm -it -p 3000:3000 uncontained-local-dev
 ----
 
-This command will run uncontained.io usin embedded copy of the source code.
+This command will run uncontained.io using embedded copy of the source code.
 
 
 If you need to run it with actual code use this:


### PR DESCRIPTION
#### What is this PR About?

This PR bumps the node version to the latest v10.x to make the local-dev build work when running under docker. 

#### How should we test or review this PR?

Follow the build steps in the `container-images/local-dev/README` file, then run/host the site locally by following the steps in the README file, or the contributor guide. 

#### Is there a relevant Trello card or Github issue open for this?

N/A

#### Who would you like to review this?

cc: @redhat-cop/cant-contain-this
cc: @etsauer 

'''''

* [x] Have you followed the
[contributing
guidelines?](https://github.com/redhat-cop/uncontained.io/blob/master/CONTRIBUTING.adoc)
* [x] Have you explained what your changes do, and why they add value to
the uncontained.io guides?

'''''

*Please note: we may close your PR without comment if you do not check
the boxes above and provide ALL requested information.*
